### PR TITLE
Auto-load all stops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_STORE

--- a/StopSelector/index.html
+++ b/StopSelector/index.html
@@ -38,12 +38,12 @@
     </div>
     <div class="row selector-holder">
       <div class="col-md-6">
-        <h2>Filter by routes</h2>
+        <h2>Filter by routes [optional]</h2>
         <select name="routes[]" class="routes" data-placeholder="Select Routes" multiple></select>
       </div>
       <div class="col-md-6">
-        <h2>Then choose stops</h2>
-        <select name="stops[]" class="route-stops stops" data-placeholder="Select Stops" multiple></select>
+        <h2>Then search stops</h2>
+        <select name="stops[]" class="route-stops stops" data-placeholder="Search or Select Stops" multiple></select>
       </div>
     </div>
     <div class="row go-button-holder">

--- a/StopSelector/index.html
+++ b/StopSelector/index.html
@@ -15,6 +15,19 @@
   <script src="js/underscore.min.js"></script>
   <script src="js/main.js"></script>
 </head>
+  <style>
+    h2 {
+      display: inline-block;
+      font-size: 1.5em;
+      margin-before: 0.83em;
+      margin-after: 0.83em;
+      margin-start: 0;
+      margin-end: 0;
+      font-weight: bold; }
+    span {
+      color: "white";
+    }
+  </style>
 <body>
   <div class="load-holder fadeable">
     <div class="loader">Loading...</div>
@@ -38,11 +51,11 @@
     </div>
     <div class="row selector-holder">
       <div class="col-md-6">
-        <h2>Filter by routes [optional]</h2>
-        <select name="routes[]" class="routes" data-placeholder="Select Routes" multiple></select>
+        <h2>Select Routes</h2> <font color="white">&nbsp;[Optional]</font>
+        <select name="routes[]" class="routes" data-placeholder="Search or Select Routes" multiple></select>
       </div>
       <div class="col-md-6">
-        <h2>Then search stops</h2>
+        <span id="stop-selector"></span>
         <select name="stops[]" class="route-stops stops" data-placeholder="Search or Select Stops" multiple></select>
       </div>
     </div>

--- a/StopSelector/js/main.js
+++ b/StopSelector/js/main.js
@@ -8,9 +8,9 @@ var options =
 }
 
 $(function() {
+  loadAllStops();
   updateOptions();
   initTitle();
-  loadAllStops();
 
   setTimeout(removeFade, 500);
   // Load the BusInfoBoard with the selected stops
@@ -23,20 +23,40 @@ $(function() {
   // List of all PVTA routes
   var routes = $('.routes');
   var routeStops = $('.route-stops');
-
+  var everyStop;
+  
   // Use the Chosen jQuery plugin for our multiple select boxes
   routes.chosen();
   routeStops.chosen();
   $('.nearby-stops').chosen();
   
+  
+  
+/**This function will download and display
+ * **all** of PVTA's stops, so that users can
+ * type in and view a specific stop or
+ * number of stops without having to first pick
+ * a route.
+ **/
   function loadAllStops(){
     var stops = [];
+    /** If we've already downloaded
+     * and sorted every stop, no
+     * need to do it again
+     **/
+    if(everyStop){
+      //Display the list of stops
+      stopList(routeStops, everyStop);
+      return;
+    }
       $.ajax({
         url: options.url + 'stops/getallstops',  
         success: function(allStops){
-          console.log(typeof allStops);
-          allStops = uniqueifyAndSort(allStops);
-          stopList(routeStops, allStops);
+          // Set the everyStop variable to the list so 
+          // we don't have to download it all again.
+          everyStop = allStops;
+          everyStop = uniqueifyAndSort(everyStop);
+          stopList(routeStops, everyStop);
         } //end success callback
     }); //end ajax call
   }
@@ -134,6 +154,23 @@ function stopList(select, stops) {
 }
 
 
+
+/**
+* This function takes in a collection,
+* (array, object, etc) 
+* It iterates over the entire thing, removes
+* duplicate values, and sorts it by the StopID.
+*
+* This isn't really usable for anything other than
+* stops rn. ISSUE: trying to pass an attribute as
+* a string param to the function causes it to
+* throw out everything except one stop.
+* 
+* @param: collection: Object
+* @return: collection: Object <-- the sorted and
+* uniquified version of your input.
+**/
+
 function uniqueifyAndSort(collection){
   collection = _.uniq(_.union(_.flatten(collection)), _.iteratee('StopId'));
   collection.sort(function(a,b) {
@@ -149,18 +186,6 @@ function uniqueifyAndSort(collection){
 }
 
 
-/*This function will download and display
- * **all** of PVTA's stops, so that users can
- * type in and view a specific stop or
- * number of stops without having to first pick
- * a route.
- * 
- * CALL WITH CAUTION: Loading and displaying a
- * list of every single stop takes ~1/4 of a second.
- * loadAllStops() is called when the page inits
- * and when the user has emptied their route
- * selections.
- */
 
 
 function populateListGeo(pos) {

--- a/StopSelector/js/main.js
+++ b/StopSelector/js/main.js
@@ -10,6 +10,7 @@ var options =
 $(function() {
   updateOptions();
   initTitle();
+  loadAllStops();
 
   setTimeout(removeFade, 500);
   // Load the BusInfoBoard with the selected stops
@@ -27,7 +28,9 @@ $(function() {
   routes.chosen();
   routeStops.chosen();
   $('.nearby-stops').chosen();
-
+  
+  
+  
   // When a route is added or removed from the list, reload the list of stops
   // accessible by those routes
   routes.on("change", function() {
@@ -52,7 +55,7 @@ $(function() {
                 return -1;
               }
               return 0
-            });
+            });;
             stopList(routeStops, stops);
           }
         }
@@ -123,6 +126,30 @@ function stopList(select, stops) {
     removeFade();
   });
 }
+
+
+/*This function will download and display
+ * **all** of PVTA's stops, so that users can
+ * type in and view a specific stop or
+ * number of stops without having to first pick
+ * a route.
+ * 
+ * CALL WITH CAUTION: Loading and displaying a
+ * list of every single stop takes ~1/4 of a second.
+ * loadAllStops() is called when the page inits
+ * and when the user has emptied their route
+ * selections.
+ */
+
+function loadAllStops(){
+      var stops = [];
+      $.ajax({
+        url: options.url + 'stops/getallstops',  
+        success: function(allStops){
+          stopList(routeStops, allStops);
+        } //end success callback
+      }); //end ajax call
+  }
 
 function populateListGeo(pos) {
   fadeBlack(function() {

--- a/StopSelector/js/main.js
+++ b/StopSelector/js/main.js
@@ -30,25 +30,15 @@ $(function() {
   $('.nearby-stops').chosen();
   
   function loadAllStops(){
-      var stops = [];
+    var stops = [];
       $.ajax({
         url: options.url + 'stops/getallstops',  
         success: function(allStops){
           console.log(typeof allStops);
-          allStops = _.uniq(_.union(_.flatten(allStops)), _.iteratee('Name'));
-          allStops.sort(function(a,b) {
-              if (a.Name > b.Name) {
-                return 1;
-              }
-              if (a.Name < b.Name) {
-                return -1;
-              }
-              return 0
-            });
+          allStops = uniqueifyAndSort(allStops);
           stopList(routeStops, allStops);
-          
         } //end success callback
-      }); //end ajax call
+    }); //end ajax call
   }
 
   
@@ -60,29 +50,23 @@ $(function() {
     var remainingRoutes = routes.length;
     var stops = [];
     // For each route selected, we get a list of stops
-    for (var i = 0; i < routes.length; i++) {
-      $.ajax({
-        url: options.url + "routedetails/get/" + routes[i],
-        success: function(route_details) {
-          stops.push(route_details.Stops);
-          remainingRoutes--;
-          if (remainingRoutes == 0) {
-            // Put all of the stops into a single array and sort them
-            stops = _.uniq(_.union(_.flatten(stops)), _.iteratee('StopId'));
-            stops.sort(function(a,b) {
-              if (a.Name > b.Name) {
-                return 1;
-              }
-              if (a.Name < b.Name) {
-                return -1;
-              }
-              return 0
-            });
-            stopList(routeStops, stops);
-          }
-        }
-      });
-    }
+    if(routes.length === 0) loadAllStops();
+    else{
+      for (var i = 0; i < routes.length; i++) {
+        $.ajax({
+          url: options.url + "routedetails/get/" + routes[i],
+          success: function(route_details) {
+            stops.push(route_details.Stops);
+            remainingRoutes--;
+            if (remainingRoutes == 0) {
+              // Put all of the stops into a single array and sort them
+              stops = uniqueifyAndSort(stops);
+              stopList(routeStops, stops);
+            }
+          } //end success callback
+        }); //end ajax call
+      } //end for
+    } //end else
   });
 
   // Ask the user for their location
@@ -147,6 +131,21 @@ function stopList(select, stops) {
     select.trigger('chosen:updated');
     removeFade();
   });
+}
+
+
+function uniqueifyAndSort(collection){
+  collection = _.uniq(_.union(_.flatten(collection)), _.iteratee('StopId'));
+  collection.sort(function(a,b) {
+  if (a.Name > b.Name) {
+    return 1;
+  }
+  if (a.Name < b.Name) {
+    return -1;
+  }
+  return 0
+  });
+  return collection;
 }
 
 

--- a/StopSelector/js/main.js
+++ b/StopSelector/js/main.js
@@ -29,6 +29,28 @@ $(function() {
   routeStops.chosen();
   $('.nearby-stops').chosen();
   
+  function loadAllStops(){
+      var stops = [];
+      $.ajax({
+        url: options.url + 'stops/getallstops',  
+        success: function(allStops){
+          console.log(typeof allStops);
+          allStops = _.uniq(_.union(_.flatten(allStops)), _.iteratee('Name'));
+          allStops.sort(function(a,b) {
+              if (a.Name > b.Name) {
+                return 1;
+              }
+              if (a.Name < b.Name) {
+                return -1;
+              }
+              return 0
+            });
+          stopList(routeStops, allStops);
+          
+        } //end success callback
+      }); //end ajax call
+  }
+
   
   
   // When a route is added or removed from the list, reload the list of stops
@@ -55,7 +77,7 @@ $(function() {
                 return -1;
               }
               return 0
-            });;
+            });
             stopList(routeStops, stops);
           }
         }
@@ -141,15 +163,6 @@ function stopList(select, stops) {
  * selections.
  */
 
-function loadAllStops(){
-      var stops = [];
-      $.ajax({
-        url: options.url + 'stops/getallstops',  
-        success: function(allStops){
-          stopList(routeStops, allStops);
-        } //end success callback
-      }); //end ajax call
-  }
 
 function populateListGeo(pos) {
   fadeBlack(function() {

--- a/StopSelector/js/main.js
+++ b/StopSelector/js/main.js
@@ -44,6 +44,7 @@ $(function() {
      * and sorted every stop, no
      * need to do it again
      **/
+    var span = document.getElementById('stop-selector').innerHTML = "<h2>Or: Search Stops</h2>";
     if(everyStop){
       //Display the list of stops
       stopList(routeStops, everyStop);
@@ -72,6 +73,7 @@ $(function() {
     // For each route selected, we get a list of stops
     if(routes.length === 0) loadAllStops();
     else{
+      var span = document.getElementById('stop-selector').innerHTML = "<h2>Now Search Stops</h2>";
       for (var i = 0; i < routes.length; i++) {
         $.ajax({
           url: options.url + "routedetails/get/" + routes[i],


### PR DESCRIPTION
I updated the BusInfoBoard's StopSelector page to automatically download and allow users to search through/choose from all of PVTA's stops.  Previously, you had to select a route and then scroll through or type in a stop name.  I made it easier to skip that step (and people don't know that you can type to search for routes/stops, so I made that a little clearer too).