### PR TITLE
Show times local to avail endpoint

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -385,7 +385,7 @@ function departureInterval(edt, offset){
 }
 
 function departureDisplayTime(edt){
-  return moment(edt).format('h:mm a');
+  return moment.parseZone(edt).format('h:mm a');
 }
 
 function alternateTimeDisplay(){


### PR DESCRIPTION
Addresses #62.

https://momentjs.com/docs/#/parsing/parse-zone/

It is now 9:10 pm local time. I confirmed that this works by temporarily setting my locale to Paris and restarting Chrome. My 'local' time was then 3:10 am. I then saw a departure listed for 3:22 am, arriving in 12 minutes. With the new code, that departure time displayed as 9:22 pm, so local to Amherst, still arriving in 12 minutes.

As I noted in #62, we should only merge this if we think the time displayed here should always be local to the timestamp returned by Avail.