### PR TITLE
Redirect StopSelector to m.pvta.com

### DIFF
--- a/StopSelector/index.html
+++ b/StopSelector/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="1; url=https://m.pvta.com/">
+    <script type="text/javascript">
+      window.location.href = "https://m.pvta.com"
+    </script>
+    <title>Redirecting to PVTrAck</title>
+  </head>
+  <body>
+    <p>The PVTA has a new bus-tracking page that replaces the stop-picking
+    features of this departure board. We're redirecting you there now. If you
+    are not redirected automatically, follow this <a href='https://m.pvta.com/'>
+    link to PVTrAck</a>.
+  </body>
+</html>


### PR DESCRIPTION
We got a phone call this week - I guess there was at least one person
regularly using the "StopSelector". I think I manages to convince him
that m.pvta.com is better, but then I started to feel guilty about
taking away a feature with no warning.

We cant do "real" 301/302 redirects on GH Pages, but we can do meta/JS
redirects.