### PR TITLE
Use `display: grid` instead of BootStrap's rows

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2,7 +2,6 @@ html, body {
   color: white;
   background-color: black;
   font-family: 'Open Sans', sans-serif;
-  box-sizing: border-box;
   font-size: 6px;
 }
 
@@ -20,11 +19,35 @@ html, body {
   }
 }
 
-/* lg */
 @media (min-width: 1200px) {
   html {
     font-size: 14px;
   }
+}
+
+/* lg */
+@media (min-width: 1920px) {
+  #main-content {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stop-container:first-child {
+    grid-column: 1 / 3;
+  }
+
+  .stop-container:first-child:nth-last-child(n+3) {
+    grid-column: 1;
+  }
+
+  .message-holder {
+    grid-column: 1 / 3;
+  }
+}
+
+#main-content {
+  display: grid;
+  column-gap: 1rem;
+  margin: 0 1rem;
 }
 
 h1 {
@@ -51,7 +74,10 @@ h2 {
   margin-bottom: 10px;
   font-size: 3rem;
   font-weight: bold;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 9fr 4fr;
+  padding: 0 2rem;
+  column-gap: 1rem;
 }
 
 .route_arrival {
@@ -65,18 +91,4 @@ h2 {
 
 p {
   font-size: 2rem;
-}
-
-.route_abbreviation {
-  flex: 1;
-  margin: 0 2rem;
-}
-
-.route_long_name {
-  flex: 9;
-}
-
-.route_arrival {
-  flex: 4;
-  margin: 0 2rem;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -69,14 +69,14 @@ p {
 
 .route_abbreviation {
   flex: 1;
-  margin-left: 2rem;
+  margin: 0 2rem;
 }
 
 .route_long_name {
-  flex: 8;
+  flex: 9;
 }
 
 .route_arrival {
-  flex: 2;
-  margin-right: 2rem;
+  flex: 4;
+  margin: 0 2rem;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -6,10 +6,6 @@ html, body {
   font-size: 6px;
 }
 
-* {
-  box-sizing: inherit;
-}
-
 /* sm */
 @media (min-width: 768px) {
   html {
@@ -55,8 +51,7 @@ h2 {
   margin-bottom: 10px;
   font-size: 3rem;
   font-weight: bold;
-  overflow: hidden;
-  padding: 0 20px;
+  display: flex;
 }
 
 .route_arrival {
@@ -70,4 +65,18 @@ h2 {
 
 p {
   font-size: 2rem;
+}
+
+.route_abbreviation {
+  flex: 1;
+  margin-left: 2rem;
+}
+
+.route_long_name {
+  flex: 8;
+}
+
+.route_arrival {
+  flex: 2;
+  margin-right: 2rem;
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 </head>
 <body>
-  <div class="container-fluid main-content"></div>
+  <div id="main-content"></div>
 
   <script src="js/jquery-1.11.0.min.js"></script>
   <script src="js/moment.min.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -70,7 +70,7 @@ function QueryStringAsObject() {
 }
 
 $(function(){
-  container = $('.main-content');
+  container = $('#main-content');
   updateOptions();
   initTitle();
   initBoard();
@@ -274,6 +274,9 @@ function addTables() {
     dst_at_start = moment([current.year(), current.month(), current.date(), options.work_day_start]).isDST();
   }
 
+  var stopContainer = $('<div class="stop-container"></div>');
+  container.append(stopContainer);
+
   // There are two separate calls here,
   $.ajax({
     url: options.url + "stops/get/" + options.stops[stop_index],
@@ -282,7 +285,7 @@ function addTables() {
         url: options.url + "stopdepartures/get/" + options.stops[stop_index],
         success: function(departure_data) {
           // Draw the header for each stop
-          container.append('<h1 class="animated ' + options.start_animation + '">' + stop_info.Description + "</h1>");
+          stopContainer.append('<h1 class="animated ' + options.start_animation + '">' + stop_info.Description + "</h1>");
           departure_data[0] = departure_data[0] || {RouteDirections: []}
           var infos = getDepartureInfo(departure_data[0].RouteDirections);
           var done = isDone(departure_data[0].RouteDirections);
@@ -293,14 +296,14 @@ function addTables() {
             } else {
               message = "No departures in the next two hours";
             }
-            container.append('<h2 class="animated ' + options.start_animation + '">' + message + '</h2>');
+            stopContainer.append('<h2 class="animated ' + options.start_animation + '">' + message + '</h2>');
           }
           var i = 0; // For that soothing cascading effect
           var id = setInterval(function() {
               // If we still have rows to render
               if (i < infos.length) {
                 if(options.showMessages !== 'only')
-                  renderRow(infos[i], container);
+                  renderRow(infos[i], stopContainer);
                 i++;
               } else { // If not, clear out the timer and move onto the next route
                 clearTimeout(id);

--- a/js/main.js
+++ b/js/main.js
@@ -274,30 +274,15 @@ function addTables() {
     dst_at_start = moment([current.year(), current.month(), current.date(), options.work_day_start]).isDST();
   }
 
-  var row, section;
-  var size_class = "";
-  if (options.stops.length > 1) {
-    size_class = "col-lg-12";
-  }
   // There are two separate calls here,
   $.ajax({
     url: options.url + "stops/get/" + options.stops[stop_index],
     success: function(stop_info) {
-      if (stop_index % 2 == 0) {
-        row = $('<div class="row route-holder"></div>');
-      } else {
-        row = $('.route-holder:last');
-      }
-      section = $('<div class="col-xs-24 ' + size_class + '"></div>"');
-      row.append(section);
-      if (stop_index % 2 == 0) {
-        container.append(row);
-      }
       $.ajax({
         url: options.url + "stopdepartures/get/" + options.stops[stop_index],
         success: function(departure_data) {
           // Draw the header for each stop
-          section.append('<h1 class="animated ' + options.start_animation + '">' + stop_info.Description + "</h1>");
+          container.append('<h1 class="animated ' + options.start_animation + '">' + stop_info.Description + "</h1>");
           departure_data[0] = departure_data[0] || {RouteDirections: []}
           var infos = getDepartureInfo(departure_data[0].RouteDirections);
           var done = isDone(departure_data[0].RouteDirections);
@@ -308,14 +293,14 @@ function addTables() {
             } else {
               message = "No departures in the next two hours";
             }
-            section.append('<h2 class="animated ' + options.start_animation + '">' + message + '</h2>');
+            container.append('<h2 class="animated ' + options.start_animation + '">' + message + '</h2>');
           }
           var i = 0; // For that soothing cascading effect
           var id = setInterval(function() {
               // If we still have rows to render
               if (i < infos.length) {
                 if(options.showMessages !== 'only')
-                  renderRow(infos[i], section);
+                  renderRow(infos[i], container);
                 i++;
               } else { // If not, clear out the timer and move onto the next route
                 clearTimeout(id);
@@ -402,9 +387,6 @@ function removeTables() {
 // at the end of 30-3 EVE, which is on route 30 and northbound, just like North Amherst,
 // but has a different trip description).
 function renderRow(info, section) {
-  var short_proportions = "col-xs-2 col-sm-2 col-md-2 col-lg-2";
-  var long_proportions = "col-xs-15 col-sm-15 col-md-15 col-lg-15";
-  var arrival_proportions = "col-xs-7 col-sm-7 col-md-7 col-lg-7";
   var offset = 0;
   // If we aren't in the same timezone as we were this morning
   if (dst_at_start != moment().isDST()) {
@@ -425,16 +407,14 @@ function renderRow(info, section) {
   section.append(
     '<div class="route animated ' + options.start_animation +
     '" style="background-color: #' + info.Route.Color + '; color: #' + info.Route.TextColor + '">' +
-      '<div class="row">' +
-        '<div class="route_abbreviation ' + short_proportions + '">' +
-          info.Route.RouteAbbreviation +
-        '</div>' +
-        '<div class="route_long_name ' + long_proportions + '">' +
-          info.Departure.Trip.InternetServiceDesc +
-        '</div>' +
-        '<div class="route_arrival ' + arrival_proportions + '" data-time="' + time + '" data-interval="' + interval + '">' +
-           startingTimeDisplay +
-        '</div>'+
+      '<div class="route_abbreviation">' +
+        info.Route.RouteAbbreviation +
+      '</div>' +
+      '<div class="route_long_name">' +
+        info.Departure.Trip.InternetServiceDesc +
+      '</div>' +
+      '<div class="route_arrival" data-time="' + time + '" data-interval="' + interval + '">' +
+         startingTimeDisplay +
       '</div>'+
     '</div>'
   );


### PR DESCRIPTION
Fixing the overlapping of columns when zoomed in. 